### PR TITLE
require set-value@^2.0.1, CVE-2019-10747

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "js-yaml": "^3.13.1",
     "mime-types": "^2.1.20",
     "minio": "^7.0.1",
+    "set-value": "^2.0.1",
     "swagger-ui-express": "^4.0.1",
     "tmp": "^0.0.33"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,8 +2392,10 @@ serve-static@1.13.2, serve-static@^1.10.0:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
   dependencies:
-    "@types/express-serve-static-core" "*"
-    "@types/mime" "*"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.2"
+    send "0.16.2"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -2411,6 +2413,16 @@ set-value@^0.4.3:
 set-value@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
+set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"


### PR DESCRIPTION
- [CVE-2019-10747](https://nvd.nist.gov/vuln/detail/CVE-2019-10747)
- high severity
- Vulnerable versions: < 2.0.1
- Patched version: 2.0.1

set-value is vulnerable to Prototype Pollution in versions before 2.0.1
and version 3.0.0. The function mixin-deep could be tricked into adding
or modifying properties of Object.prototype using any of the
constructor, prototype and proto payloads.